### PR TITLE
Added scaleTo(): allow (almost) arbitrary scaling up and down

### DIFF
--- a/plants/autoscaler.py
+++ b/plants/autoscaler.py
@@ -161,6 +161,22 @@ class AutoScaler:
 				BackendStatus.STOPPING: numStopping,
 			}
 
+	## Scale to a given number of replicas
+	# Implemented in a FIFO-like manner, i.e., first backend added is first started.
+	def scaleTo(self, numReplicas):
+		while True:
+			status = self.getStatus()
+			numReplicasThatWillBeStarted = \
+				+ status[BackendStatus.STARTING] \
+				+ status[BackendStatus.STARTED]
+
+			if numReplicas > numReplicasThatWillBeStarted:
+				self.scaleUp()
+			elif numReplicas < numReplicasThatWillBeStarted:
+				self.scaleDown()
+			else:
+				break
+
 	## Scale up by one replica.
 	# Implemented in a FIFO-like manner, i.e., first backend added is first started.
 	def scaleUp(self):

--- a/plants/autoscaler_test.py
+++ b/plants/autoscaler_test.py
@@ -131,6 +131,60 @@ def test_scale_up_and_down():
 
     assert loadBalancer.lastRemovedBackend == server2
 
+def test_scale_up_and_down_multiple():
+    sim = SimulatorKernel(outputDirectory = None)
+
+    loadBalancer = MockLoadBalancer(sim, latency = 1)
+    autoScaler = AutoScaler(sim, loadBalancer, startupDelay = 60)
+    assert str(autoScaler)
+
+    server1 = mock.Mock(name = 'server1')
+    server2 = mock.Mock(name = 'server2')
+    server3 = mock.Mock(name = 'server3')
+    server4 = mock.Mock(name = 'server4')
+    autoScaler.addBackend(server1)
+    autoScaler.addBackend(server2)
+    autoScaler.addBackend(server3)
+    autoScaler.addBackend(server4)
+
+    def assert_autoscaler_status_is(stopped, starting, started, stopping):
+        status = autoScaler.getStatus()
+        assert status[BackendStatus.STOPPED ] == stopped , stopped
+        assert status[BackendStatus.STARTING] == starting, starting
+        assert status[BackendStatus.STARTED ] == started , started
+        assert status[BackendStatus.STOPPING] == stopping, stopping
+
+    sim.add(0, lambda: assert_autoscaler_status_is(4, 0, 0, 0))
+
+    sim.add(10, lambda: autoScaler.scaleTo(2))
+    sim.add(10, lambda: assert_autoscaler_status_is(2, 2, 0, 0))
+
+    sim.add(10+59, lambda: loadBalancer.addBackend.assert_not_called()) # startup delay
+    sim.add(10+59, lambda: assert_autoscaler_status_is(2, 2, 0, 0))
+
+    sim.add(10+60+eps, lambda: assert_autoscaler_status_is(2, 0, 2, 0))
+    calls1 = [mock.call(server1), mock.call(server2)]
+    sim.add(10+60+eps, lambda: loadBalancer.addBackend.assert_has_calls(calls1))
+
+    sim.add(100, lambda: autoScaler.scaleTo(4))
+    sim.add(100, lambda: assert_autoscaler_status_is(0, 2, 2, 0))
+
+    sim.add(100+59, lambda: assert_autoscaler_status_is(0, 2, 2, 0))
+
+    sim.add(100+60+eps, lambda: assert_autoscaler_status_is(0, 0, 4, 0))
+    calls2 = [mock.call(server3), mock.call(server4)]
+    sim.add(100+60+eps, lambda: loadBalancer.addBackend.assert_has_calls(calls2))
+
+    sim.add(200, lambda: autoScaler.scaleTo(1))
+    sim.add(200, lambda: assert_autoscaler_status_is(0, 0, 1, 3))
+
+    sim.add(200+1-eps, lambda: assert_autoscaler_status_is(0, 0, 1, 3))
+    sim.add(200+1+eps, lambda: assert_autoscaler_status_is(3, 0, 1, 0))
+
+    sim.run()
+
+    assert loadBalancer.lastRemovedBackend == server2
+
 @raises(RuntimeError)
 def test_invalid_action():
     sim = SimulatorKernel(outputDirectory = None)


### PR DESCRIPTION
Added `scaleTo()` to allow scaling to an arbitrary number of replicas. In essence, the controller can call `scale(3)` and the auto-scaler will ensure that 3 replicas are (eventually) started. See test-case for specification on how it is supposed to work.

Please note that right now `scaleTo()` is **not** robust to all kind of scaling commands. For example, repeatedly scaling up and down, without waiting for replicas to actually start will likely wait with something like `AutoScaler was asked to scale up, but no backends are available.`. We can make the auto-scaler more robust, then again, I feel it makes more sense to fail loudly if the controller acts randomly. Let me know what you prefer.
