### PR TITLE
Add multiple cores

### DIFF
--- a/plants/server.py
+++ b/plants/server.py
@@ -20,12 +20,14 @@ class Server:
 	# @param minimumServiceTime minimum service-time (despite variance)
 	# @param timeSlice time slice; a request longer that this will observe
 	# context-switching
+	# @param numCores number of cores to simulate (M/M/c queue is assumed)
 	# @note The constructor adds an event into the simulator
 	def __init__(self, sim, seed = 1,
 			timeSlice = 0.01, \
 			serviceTimeY = 0.07, serviceTimeN = 0.001, \
 			serviceTimeYVariance = 0.01, serviceTimeNVariance = 0.001, \
-			minimumServiceTime = 0.0001):
+			minimumServiceTime = 0.0001,
+			numCores = 1):
 		## time slice for scheduling requests (server model parameter)
 		self.timeSlice = timeSlice
 		## service time with optional content (server model parameter)
@@ -46,6 +48,8 @@ class Server:
 		self.latestLatencies = []
 		## reference to controller
 		self.controller = None
+		## number of cores
+		self.numCores = numCores
 
 		## The amount of time this server is active. Useful to compute utilization
 		# Since we are in a simulator, this value is hard to use correctly. Use getActiveTime() instead.

--- a/plants/server.py
+++ b/plants/server.py
@@ -179,6 +179,8 @@ class Server:
 		# Schedule it to run for a bit
 		timeToExecuteActiveRequest = min(self.timeSlice, activeRequest.remainingTime)
 		activeRequest.remainingTime -= timeToExecuteActiveRequest
+		# XXX: Below is a very crude multi-core model. Should work for PS.
+		timeToExecuteActiveRequest /= self.numCores
 
 		# Will it finish?
 		if activeRequest.remainingTime == 0:
@@ -206,7 +208,8 @@ class Server:
 	# @param request request that has received enough service time
 	def onCompleted(self, request):
 		# Track utilization
-		self.__activeTime += self.sim.now - self.__activeTimeStarted
+		self.__activeTime += (self.sim.now - self.__activeTimeStarted) \
+			* self.numCores
 		self.__activeTimeStarted = None
 
 		# Remove request from active list

--- a/plants/server_test.py
+++ b/plants/server_test.py
@@ -78,3 +78,29 @@ def test_with_controller_always_yes():
 
     assert set(completedRequests) == set([ r, r2 ])
     assert abs(server.getActiveTime() - 20.0) < eps, server.getActiveTime()
+
+def test_without_controller_fifo():
+    completedRequests = []
+    endTimes = []
+    sim = SimulatorKernel(outputDirectory = None)
+
+    server = Server(sim, serviceTimeY = 1, serviceTimeYVariance = 0,
+                    timeSlice = 100)
+
+    def onCompleted(r):
+        completedRequests.append(r)
+        endTimes.append(sim.now)
+
+    r = Request()
+    r.onCompleted = lambda: onCompleted(r)
+    sim.add(0, lambda: server.request(r))
+    
+    r2 = Request()
+    r2.onCompleted = lambda: onCompleted(r2)
+    sim.add(0, lambda: server.request(r2))
+
+    sim.run()
+
+    assert set(completedRequests) == set([ r, r2 ])
+    assert endTimes == [1, 2], endTimes
+    assert server.getActiveTime() == 2.0, server.getActiveTime()


### PR DESCRIPTION
I added a very crude multi-core model, which should give reasonable results with processor sharing and small time slices. It is basically equivalent to dividing the service times by the number of cores.

If we want to support multi-core with larger time slices or even FIFO, then more intrusive changes are required.